### PR TITLE
fix(protocol): prevent 1.26.40 client disconnects

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/AddPlayerPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AddPlayerPacket.php
@@ -65,7 +65,7 @@ class AddPlayerPacket extends DataPacket{
 	public array $links = [];
 
 	public string $deviceId = ""; //TODO: fill player's device ID (???)
-	public int $buildPlatform = DeviceOS::UNKNOWN;
+	public int $buildPlatform = DeviceOS::ANDROID;
 
 	protected function decodePayload() : void{
 		$this->uuid = $this->getUUID();

--- a/src/pocketmine/network/mcpe/protocol/types/LegacySkinAdapter.php
+++ b/src/pocketmine/network/mcpe/protocol/types/LegacySkinAdapter.php
@@ -38,7 +38,7 @@ class LegacySkinAdapter implements SkinAdapter{
 				$skin->getSkinImage(),
 				$skin->getAnimations(),
 				$skin->getCape()->getImage(),
-				$skin->getGeometryData()
+				$skin->getGeometryData() === "" ? "{}" : $skin->getGeometryData()
 			);
 	}
 

--- a/src/pocketmine/network/mcpe/protocol/types/PlayerListEntry.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PlayerListEntry.php
@@ -36,7 +36,7 @@ class PlayerListEntry{
 	public SkinData $skinData;
 	public string $xboxUserId;
 	public string $platformChatId = "";
-	public int $buildPlatform = DeviceOS::UNKNOWN;
+	public int $buildPlatform = DeviceOS::ANDROID;
 	public bool $isTeacher = false;
 	public bool $isHost = false;
 	public bool $isSubClient = false;
@@ -50,7 +50,7 @@ class PlayerListEntry{
 		return $entry;
 	}
 
-	public static function createAdditionEntry(UUID $uuid, int $entityUniqueId, string $username, SkinData $skinData, string $xboxUserId = "", string $platformChatId = "", int $buildPlatform = -1, bool $isTeacher = false, bool $isHost = false, bool $isSubClient = false, ?Color $color = null) : PlayerListEntry{
+	public static function createAdditionEntry(UUID $uuid, int $entityUniqueId, string $username, SkinData $skinData, string $xboxUserId = "", string $platformChatId = "", int $buildPlatform = DeviceOS::ANDROID, bool $isTeacher = false, bool $isHost = false, bool $isSubClient = false, ?Color $color = null) : PlayerListEntry{
 		$entry = new PlayerListEntry();
 		$entry->type = PlayerListPacket::TYPE_ADD;
 		$entry->uuid = $uuid;


### PR DESCRIPTION
## 변경 내용

- 빈 스킨 geometry 데이터를 유효한 {} JSON으로 보정합니다.
- AddPlayer와 PlayerList의 기본 build platform을 Android(1)로 지정합니다.

## 원인

1.26.40 클라이언트는 빈 geometry 또는 UNKNOWN(-1) platform 값이 포함된 플레이어 데이터를 처리하는 과정에서 연결을 종료할 수 있습니다.

## 검증

- Dragonfly와 Nukkit의 1.26.40 호환 구현을 대조했습니다.
- BetterAltay 최신 브랜치에 이미 포함된 MovePlayer 및 PlayerAuthInput 패치는 중복 적용하지 않았습니다.
- 변경 파일 diff 검사를 통과했습니다.